### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "nguyenanhung/hashids-helper": "^2.0",
         "nguyenanhung/slug-helper": "^3.0 || ^2.0",
         "nguyenanhung/nanoid-helper": "^2.0",
-        "nguyenanhung/escape-helper": "^3.0 || ^2.0",
-        "paragonie/random_compat": ">=2.0"
+        "nguyenanhung/escape-helper": "^3.0 || ^2.0"
     },
     "require-dev": {
         "kint-php/kint": ">=3.0"


### PR DESCRIPTION
This package depends on `paragonie/random_compat: >=2.0`, but also `php: >=7.0`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?